### PR TITLE
Accordo path configurations

### DIFF
--- a/examples/configurations/cursor/README.md
+++ b/examples/configurations/cursor/README.md
@@ -2,6 +2,16 @@
 
 This directory contains example MCP configurations for Cursor. These configurations show how to set up Workflow Commander with different feature sets and options.
 
+## 🆕 New Flag System
+
+**Recent Update**: Repository path configuration now uses simple `--global` and `--local` flags instead of `--repository-path`:
+
+- **`--global`**: Uses home directory (`~/.accordo/`) - **recommended for global Cursor MCP servers**
+- **`--local`**: Uses current directory (`./.accordo/`) - **ideal for project-specific configurations**
+- **`--repository-path`**: Still supported but deprecated - shows warning message
+
+**Migration**: Update your configurations to use the new flags for better Cursor compatibility!
+
 ## Configuration Files
 
 ### 1. Basic Setup (`basic-setup.json`)
@@ -9,16 +19,16 @@ This directory contains example MCP configurations for Cursor. These configurati
 **Purpose**: Minimal configuration for getting started with Workflow Commander in Cursor.
 
 **Features**:
-- Standard uvx-based installation from GitHub
+- Standard uvx-based installation from PyPI
 - No additional command line arguments
-- Uses default settings
+- Uses default settings (home directory: `~/.accordo/`)
 
 ### 2. Advanced Setup (`advanced-setup.json`)
 
 **Purpose**: Configuration with comprehensive command line options including cache features.
 
 **Features**:
-- Repository path specification (`--repository-path`)
+- Current directory as repository root (`--local`)
 - Local state file synchronization enabled (`--enable-local-state-file`)
 - JSON format for state files (`--local-state-file-format JSON`)
 - Custom session retention period (`--session-retention-hours 72`)
@@ -32,20 +42,60 @@ This directory contains example MCP configurations for Cursor. These configurati
 **Purpose**: Focused configuration highlighting cache features for semantic workflow analysis.
 
 **Features**:
+- Current directory as repository root (`--local`)
 - Essential cache configuration for semantic search
 - Optimized for workflow state persistence and discovery
 - Includes both local file storage and cache mode
 - Performance-tuned embedding model selection
 
+### 4. Specific Version Setup (`specific-version.json`)
+
+**Purpose**: Configuration pinned to a specific package version with global repository.
+
+**Features**:
+- Pinned to specific version (`accordo-workflow-mcp==0.1.0`)
+- Home directory repository root (`--global`) - ideal for global MCP
+- Full cache and state management features
+- Higher quality embedding model (`all-mpnet-base-v2`)
+
+### 5. PyPI Latest Setup (`pypi-latest.json`)
+
+**Purpose**: Always use the latest version from PyPI with global configuration.
+
+**Features**:
+- Latest PyPI version (no version pinning)
+- Home directory repository root (`--global`)
+- Full feature set enabled
+- Production-ready configuration
+
+### 6. Git Versions Setup (`git-versions.json`)
+
+**Purpose**: Examples of installing from specific Git references.
+
+**Features**:
+- Installation by tag, commit, or branch
+- Shows different Git-based installation methods
+- No additional configuration - uses defaults
+
 **Command Line Arguments Explained**:
 
 #### Repository Configuration
 
-##### `--repository-path`
-- **Purpose**: Specify the repository root where `.accordo` folder should be located
-- **Default**: Current directory
+##### `--global` / `--local` (Recommended)
+- **Purpose**: Choose repository location using simple flags
+- **`--global`**: Uses home directory (`~/.accordo/`) - **recommended for global MCP servers**
+- **`--local`**: Uses current directory (`./.accordo/`) - **ideal for project-specific setups**
+- **Default**: Home directory if no flag specified
+- **Benefits**: 
+  - Clearer than absolute paths
+  - Better for Cursor global MCP configurations
+  - Prevents working directory issues
+
+##### `--repository-path` (Deprecated)
+- **⚠️ DEPRECATED**: Use `--global` or `--local` instead
+- **Purpose**: Specify absolute path to repository root where `.accordo` folder should be located
 - **Example**: `--repository-path /path/to/your/project`
-- **Use Case**: Essential for project-specific workflow organization
+- **Migration**: Replace with `--local` for current directory or `--global` for home directory
 
 #### State File Configuration
 
@@ -151,9 +201,7 @@ Create `.cursor/mcp.json` in your project root for project-specific settings:
       "command": "uvx",
       "args": [
         "accordo-workflow-mcp",
-        "accordo-mcp",
-        "--repository-path",
-        "/path/to/your/project"
+        "--local"
       ]
     }
   }
@@ -167,16 +215,14 @@ Create `.cursor/mcp.json` in your project root for project-specific settings:
     "accordo": {
       "command": "uvx",
       "args": [
-        
         "accordo-workflow-mcp",
-        "accordo-mcp",
-        "--repository-path",
-        "/path/to/your/project",
+        "--local",
         "--enable-local-state-file",
         "--local-state-file-format",
         "JSON",
         "--session-retention-hours",
         "72",
+        "--enable-cache-mode",
         "--cache-db-path",
         ".accordo/cache",
         "--cache-embedding-model",
@@ -189,25 +235,21 @@ Create `.cursor/mcp.json` in your project root for project-specific settings:
 }
 ```
 
-### Performance-Optimized Setup (Large Projects)
+### Global MCP Setup (Recommended for Cursor)
 ```json
 {
   "mcpServers": {
     "accordo": {
       "command": "uvx",
       "args": [
-        
         "accordo-workflow-mcp",
-        "accordo-mcp",
-        "--repository-path",
-        "/path/to/your/project",
+        "--global",
         "--enable-local-state-file",
         "--local-state-file-format",
         "JSON",
         "--session-retention-hours",
-        "72",
-        "--cache-db-path",
-        ".accordo/cache",
+        "168",
+        "--enable-cache-mode",
         "--cache-embedding-model",
         "all-MiniLM-L6-v2",
         "--cache-max-results",

--- a/examples/configurations/cursor/advanced-setup.json
+++ b/examples/configurations/cursor/advanced-setup.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "accordo-workflow-mcp", 
-        "--repository-path", ".",
+        "--local",
         "--enable-local-state-file",
         "--local-state-file-format", "JSON",
         "--session-retention-hours", "72",

--- a/examples/configurations/cursor/cache-enabled-setup.json
+++ b/examples/configurations/cursor/cache-enabled-setup.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "accordo-workflow-mcp", 
-        "--repository-path", ".",
+        "--local",
         "--enable-local-state-file",
         "--local-state-file-format", "JSON",
         "--enable-cache-mode",

--- a/examples/configurations/cursor/pypi-latest.json
+++ b/examples/configurations/cursor/pypi-latest.json
@@ -4,8 +4,7 @@
       "command": "uvx",
       "args": [
         "accordo-workflow-mcp",
-        "--repository-path", 
-        "/home/gabe4game/Repositories/workflow-commander",
+        "--global",
         "--enable-local-state-file",
         "--local-state-file-format",
         "JSON",

--- a/examples/configurations/cursor/specific-version.json
+++ b/examples/configurations/cursor/specific-version.json
@@ -4,8 +4,7 @@
       "command": "uvx",
       "args": [
         "accordo-workflow-mcp==0.1.0",
-        "--repository-path", 
-        "/home/gabe4game/Repositories/workflow-commander",
+        "--global",
         "--enable-local-state-file",
         "--local-state-file-format",
         "JSON",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,6 @@ sonar.organization=anduril-code
  
 sonar.python.coverage.reportPaths=./coverage.xml
 sonar.python.version=3.12
+
+# Coverage exclusions - files to exclude from coverage analysis
+sonar.coverage.exclusions=**/tests/**,**/test_*/**,**/examples/**,**/cli.py,**/setup.py,**/conftest.py,**/__main__.py

--- a/src/accordo_cli/models/config.py
+++ b/src/accordo_cli/models/config.py
@@ -43,8 +43,7 @@ class TemplateConfig(BaseModel):
             description="Configuration with comprehensive command line options including cache features",
             args=[
                 "accordo-workflow-mcp",
-                "--repository-path",
-                ".",
+                "--local",
                 "--enable-local-state-file",
                 "--local-state-file-format",
                 "JSON",
@@ -68,8 +67,7 @@ class TemplateConfig(BaseModel):
             description="Focused configuration highlighting cache features for semantic workflow analysis",
             args=[
                 "accordo-workflow-mcp",
-                "--repository-path",
-                ".",
+                "--local",
                 "--enable-local-state-file",
                 "--local-state-file-format",
                 "JSON",
@@ -189,9 +187,25 @@ class ConfigurationBuilder:
             else:
                 i += 1
 
+    def add_global_flag(self) -> "ConfigurationBuilder":
+        """Add --global flag for home directory repository root."""
+        self._update_or_add_option(
+            "--global", None, "Use home directory as repository root", False
+        )
+        return self
+
+    def add_local_flag(self) -> "ConfigurationBuilder":
+        """Add --local flag for current directory repository root."""
+        self._update_or_add_option(
+            "--local", None, "Use current directory as repository root", False
+        )
+        return self
+
     def add_repository_path(self, path: str = ".") -> "ConfigurationBuilder":
-        """Add repository path option."""
-        self._update_or_add_option("--repository-path", path, "Repository root path")
+        """[DEPRECATED] Add repository path option. Use add_global_flag() or add_local_flag() instead."""
+        self._update_or_add_option(
+            "--repository-path", path, "[DEPRECATED] Repository root path"
+        )
         return self
 
     def enable_local_state_file(

--- a/src/accordo_cli/utils/prompts.py
+++ b/src/accordo_cli/utils/prompts.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import click
 import typer
 
 from ..models.config import (
@@ -137,7 +138,7 @@ def customize_configuration(builder: ConfigurationBuilder) -> ConfigurationBuild
     repo_choice = typer.prompt(
         "Repository location (global/local/custom)",
         default=current_choice,
-        type=typer.Choice(["global", "local", "custom"]),
+        type=click.Choice(["global", "local", "custom"]),
     )
 
     if repo_choice == "global":
@@ -261,7 +262,7 @@ def build_custom_configuration() -> ConfigurationBuilder:
     repo_choice = typer.prompt(
         "Repository location (global=home directory, local=current directory, custom=specify path)",
         default="global",
-        type=typer.Choice(["global", "local", "custom"]),
+        type=click.Choice(["global", "local", "custom"]),
     )
 
     if repo_choice == "global":

--- a/src/accordo_cli/utils/prompts.py
+++ b/src/accordo_cli/utils/prompts.py
@@ -120,12 +120,54 @@ def customize_configuration(builder: ConfigurationBuilder) -> ConfigurationBuild
     )
     typer.echo()
 
-    # Repository path
-    current_repo_path = next(
-        (opt.value for opt in builder.options if opt.flag == "--repository-path"), "."
+    # Repository location choice
+    has_global = any(opt.flag == "--global" for opt in builder.options)
+    has_local = any(opt.flag == "--local" for opt in builder.options)
+    has_repository_path = any(
+        opt.flag == "--repository-path" for opt in builder.options
     )
-    new_repo_path = typer.prompt("Repository path", default=current_repo_path)
-    if new_repo_path != current_repo_path:
+
+    if has_global or has_local or has_repository_path:
+        current_choice = (
+            "global" if has_global else ("local" if has_local else "custom")
+        )
+    else:
+        current_choice = "global"  # Default
+
+    repo_choice = typer.prompt(
+        "Repository location (global/local/custom)",
+        default=current_choice,
+        type=typer.Choice(["global", "local", "custom"]),
+    )
+
+    if repo_choice == "global":
+        # Remove any existing repo options and add global flag
+        builder.options = [
+            opt
+            for opt in builder.options
+            if opt.flag not in ["--global", "--local", "--repository-path"]
+        ]
+        builder.add_global_flag()
+    elif repo_choice == "local":
+        # Remove any existing repo options and add local flag
+        builder.options = [
+            opt
+            for opt in builder.options
+            if opt.flag not in ["--global", "--local", "--repository-path"]
+        ]
+        builder.add_local_flag()
+    else:  # custom
+        # Ask for custom path and use deprecated repository-path option
+        current_repo_path = next(
+            (opt.value for opt in builder.options if opt.flag == "--repository-path"),
+            ".",
+        )
+        new_repo_path = typer.prompt("Repository path", default=current_repo_path)
+        builder.options = [
+            opt
+            for opt in builder.options
+            if opt.flag not in ["--global", "--local", "--repository-path"]
+        ]
         builder.add_repository_path(new_repo_path)
 
     # Local state file
@@ -215,9 +257,23 @@ def build_custom_configuration() -> ConfigurationBuilder:
 
     builder = ConfigurationBuilder()
 
-    # Repository path
-    repo_path = typer.prompt("Repository path", default=".")
-    builder.add_repository_path(repo_path)
+    # Repository location choice
+    repo_choice = typer.prompt(
+        "Repository location (global=home directory, local=current directory, custom=specify path)",
+        default="global",
+        type=typer.Choice(["global", "local", "custom"]),
+    )
+
+    if repo_choice == "global":
+        builder.add_global_flag()
+        typer.echo("  → Using home directory (~/.accordo/)")
+    elif repo_choice == "local":
+        builder.add_local_flag()
+        typer.echo("  → Using current directory (./.accordo/)")
+    else:  # custom
+        repo_path = typer.prompt("Repository path", default=".")
+        builder.add_repository_path(repo_path)
+        typer.echo(f"  → Using custom path: {repo_path}/.accordo/")
 
     # Local state file
     if typer.confirm("Enable local state file storage?", default=True):

--- a/src/accordo_workflow_mcp/config.py
+++ b/src/accordo_workflow_mcp/config.py
@@ -23,7 +23,7 @@ class ServerConfig:
 
         Args:
             repository_path: Optional path to the repository root where .accordo
-                           folder should be located. Defaults to current directory.
+                           folder should be located. Defaults to home directory.
             enable_local_state_file: Enable automatic synchronization of workflow state
                                    to local files in .accordo/sessions/.
             local_state_file_format: Format for local state files ('MD' or 'JSON').
@@ -38,7 +38,7 @@ class ServerConfig:
         if repository_path:
             self.repository_path = Path(repository_path).resolve()
         else:
-            self.repository_path = Path.cwd()
+            self.repository_path = Path.home()
 
         # Validate the repository path exists
         if not self.repository_path.exists():

--- a/src/accordo_workflow_mcp/server.py
+++ b/src/accordo_workflow_mcp/server.py
@@ -26,7 +26,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Run with default repository path (current directory)
+  # Run with default repository path (home directory)
   %(prog)s
   
   # Run with specific repository path
@@ -50,7 +50,7 @@ Examples:
         "--repository-path",
         type=str,
         help="Path to the repository root where .accordo folder should be located. "
-        "Defaults to current directory if not specified.",
+        "Defaults to home directory if not specified.",
         metavar="PATH",
     )
 
@@ -142,7 +142,7 @@ def main():
         server_config = ServerConfiguration(
             repository_path=Path(args.repository_path)
             if args.repository_path
-            else Path.cwd(),
+            else Path.home(),
             enable_local_state_file=args.enable_local_state_file,
             local_state_file_format=args.local_state_file_format.upper(),
             session_retention_hours=args.session_retention_hours,

--- a/src/accordo_workflow_mcp/services/config_service.py
+++ b/src/accordo_workflow_mcp/services/config_service.py
@@ -226,7 +226,7 @@ class ServerConfiguration(BaseModel):
     """Server-specific configuration settings."""
 
     repository_path: Path = Field(
-        default_factory=lambda: Path.cwd(),
+        default_factory=lambda: Path.home(),
         description="Repository root path where .accordo folder is located",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,7 +305,7 @@ class TestPrompts:
                 side_effect=[
                     "custom-server",  # Server name
                     4,  # Custom configuration
-                    ".",  # Repository path
+                    "global",  # Repository location choice
                     "JSON",  # State file format
                     72,  # Session retention
                     "all-MiniLM-L6-v2",  # Embedding model
@@ -326,7 +326,7 @@ class TestPrompts:
             name, config = get_workflow_commander_details()
             assert name == "custom-server"
             assert config.command == "uvx"
-            assert "--repository-path" in config.args
+            assert "--global" in config.args
 
 
 class TestModels:
@@ -450,7 +450,7 @@ class TestConfigurationTemplates:
         template = TemplateConfig.get_advanced_template()
         assert template.name == "Advanced Setup"
         assert "comprehensive command line options" in template.description
-        assert "--repository-path" in template.args
+        assert "--local" in template.args
         assert "--enable-local-state-file" in template.args
         assert "--enable-cache-mode" in template.args
         assert "--cache-embedding-model" in template.args
@@ -517,7 +517,7 @@ class TestConfigurationBuilder:
 
         # Check that template options are parsed
         flags = [opt.flag for opt in builder.options]
-        assert "--repository-path" in flags
+        assert "--local" in flags
         assert "--enable-cache-mode" in flags
 
     def test_builder_add_repository_path(self):
@@ -679,7 +679,7 @@ class TestEnhancedPrompts:
             name, config = get_workflow_commander_details()
             assert name == "test-server"
             assert config.command == "uvx"
-            assert "--repository-path" in config.args  # Advanced template includes this
+            assert "--local" in config.args  # Advanced template includes this
 
     def test_get_workflow_commander_details_with_customization(self):
         """Test enhanced function with template customization."""
@@ -691,6 +691,7 @@ class TestEnhancedPrompts:
                 side_effect=[
                     "custom-server",  # Server name
                     1,  # Basic template
+                    "custom",  # Repository location choice
                     "/custom/path",  # Repository path customization
                 ],
             ),

--- a/tests/test_services/test_config_service.py
+++ b/tests/test_services/test_config_service.py
@@ -29,7 +29,7 @@ class TestServerConfiguration:
         """Test default server configuration."""
         config = ServerConfiguration()
 
-        assert config.repository_path == Path.cwd()
+        assert config.repository_path == Path.home()
         assert config.enable_local_state_file is False
         assert config.local_state_file_format == "MD"
         assert config.session_retention_hours == 168


### PR DESCRIPTION
This pull request introduces a new flag system for repository path configuration, replacing the deprecated `--repository-path` option with `--global` and `--local` flags. It also updates configuration files, CLI prompts, and server logic to reflect this change, while maintaining backward compatibility. Additionally, several tests and documentation have been updated to align with the new system.

### New Flag System for Repository Configuration:
* Introduced `--global` (home directory) and `--local` (current directory) flags for repository path configuration, deprecating the `--repository-path` option. The new flags simplify usage and prevent working directory issues (`examples/configurations/cursor/README.md`, [[1]](diffhunk://#diff-762318364ea496f6a51f75c2bd9ff7484eb1aaaaf3641fef06464d0e477e5f49R5-R31); `src/accordo_workflow_mcp/server.py`, [[2]](diffhunk://#diff-60d90cb3f0218d5fcc384dd5c921c945ccc40bffbf2ffb35d86ebe50a61cbec8L29-R78) [[3]](diffhunk://#diff-60d90cb3f0218d5fcc384dd5c921c945ccc40bffbf2ffb35d86ebe50a61cbec8R166-R183).
* Updated CLI prompts to guide users in selecting repository location (`src/accordo_cli/utils/prompts.py`, [[1]](diffhunk://#diff-1de25c945e7c8769f756f9ca77a4dd23bb60849440d09e961dedb9d04eb584e7L123-R170) [[2]](diffhunk://#diff-1de25c945e7c8769f756f9ca77a4dd23bb60849440d09e961dedb9d04eb584e7L218-R276).

### Configuration Updates:
* Updated example configuration files to use `--global` or `--local` instead of `--repository-path` (`examples/configurations/cursor/*.json`, [[1]](diffhunk://#diff-8ba0a63fac7958102cd7b96778e14c52133b35b55eaa15d93aa9c9dbe49b9e37L7-R7) [[2]](diffhunk://#diff-51a772a633163d1b156237f16a6ecc48e4e015a51d28617f6c9da397a5f5be13L7-R7) [[3]](diffhunk://#diff-55d07824f1d6f9ae896305fd49bf6b55e941e097b96a11c853bf2c5f2a786e49L7-R7) [[4]](diffhunk://#diff-127e84521ab7009862d7909da565f5e48783ddae492eec81e049fa562c484940L7-R7).
* Modified default repository path in `ServerConfiguration` to use the home directory instead of the current directory (`src/accordo_workflow_mcp/config.py`, [[1]](diffhunk://#diff-a04b9136b9559f848a5c0af404e4298145240ce47f71ea5a329986209f160c0fL26-R26) [[2]](diffhunk://#diff-a04b9136b9559f848a5c0af404e4298145240ce47f71ea5a329986209f160c0fL41-R41); `src/accordo_workflow_mcp/services/config_service.py`, [[3]](diffhunk://#diff-12f93338b298e1c2df454a4f6fdd56b805a5c097eae7322eb24646ad11986d42L229-R229).

### Deprecation Warnings:
* Added warnings for the use of the deprecated `--repository-path` option, encouraging migration to the new flags (`src/accordo_workflow_mcp/server.py`, [src/accordo_workflow_mcp/server.pyR166-R183](diffhunk://#diff-60d90cb3f0218d5fcc384dd5c921c945ccc40bffbf2ffb35d86ebe50a61cbec8R166-R183)).
* Updated documentation and examples to reflect the deprecation (`examples/configurations/cursor/README.md`, [examples/configurations/cursor/README.mdR45-R98](diffhunk://#diff-762318364ea496f6a51f75c2bd9ff7484eb1aaaaf3641fef06464d0e477e5f49R45-R98)).

### Test Enhancements:
* Updated tests to validate the new flag system, including deprecation warnings for `--repository-path` (`tests/test_server.py`, [[1]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acL150-R160) [[2]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acR318).

### Additional Improvements:
* Added helper methods (`add_global_flag`, `add_local_flag`) to streamline flag usage in configuration builders (`src/accordo_cli/models/config.py`, [src/accordo_cli/models/config.pyR190-R208](diffhunk://#diff-559b0df2eea59d94a5d3686e2cb0b90bfdc8ca5e710bee5cd4261866d605fb5aR190-R208)).