### PR TITLE
fix: align local repository path behavior with repository-path option

### DIFF
--- a/src/accordo_workflow_mcp/server.py
+++ b/src/accordo_workflow_mcp/server.py
@@ -167,7 +167,9 @@ def main():
         if args.global_repo:
             repository_path = Path.home()
         elif args.local_repo:
-            repository_path = Path.cwd()
+            # FIX: Make --local equivalent to --repository-path .
+            # Use Path(".") to match --repository-path . behavior exactly
+            repository_path = Path(".")
         elif args.repository_path:
             # Show deprecation warning for --repository-path usage
             print(


### PR DESCRIPTION
- Updated the handling of the --local_repo argument to set the repository path to Path(".") for consistency with the --repository-path . behavior.
- This change ensures that both options yield the same result, improving user experience and reducing confusion.